### PR TITLE
changed setting fixture to create setting has with JSON instead of eval

### DIFF
--- a/fixtures/settingfixture/settingfixture.cpp
+++ b/fixtures/settingfixture/settingfixture.cpp
@@ -89,7 +89,7 @@ bool SettingFixture::execute(void * /*objectInstance*/, QString actionName, QHas
 
 QString SettingFixture::editSettings(QSettings& settings, const QString& action, QHash<QString, QString> parameters)
 {
-    QString hashEntity = ":%1 =>'%2'";
+    QString hashEntity = "\"%1\": \"%2\"";
     parameters.remove(OBJECT_TYPE);
     QString returnValue;
 


### PR DESCRIPTION
This fixes settings problem with eval hash creation
