### PR TITLE
Fix wrong return value

### DIFF
--- a/tascore/services/interactionhandlers/gestures/tasgesturerecognizers.cpp
+++ b/tascore/services/interactionhandlers/gestures/tasgesturerecognizers.cpp
@@ -298,7 +298,7 @@ TasGesture* RotationTasGestureRecognizer::create(TargetData data)
     TasCommand& command = *data.command;
 
     if(!validateRotationParams(command)){
-        return false;
+        return 0;
     }
 
     QPoint point = data.targetPoint;


### PR DESCRIPTION
This caused a compiler error with clang under OS X:

```
services/interactionhandlers/gestures/tasgesturerecognizers.cpp:301:16:
error: cannot initialize return object of type 'TasGesture *' with an rvalue
of type 'bool'
        return false;
               ^~~~~
```
