### PR TITLE
Support for QObject based QML objects and a screenshot related fixes

### DIFF
--- a/tascore/corelib/tasuitraverser.cpp
+++ b/tascore/corelib/tasuitraverser.cpp
@@ -182,6 +182,13 @@ void TasUiTraverser::traverseObject(TasObject& objectInfo, QObject* object, TasC
             foreach(QQuickItem* child, quickItem->childItems()) {
                 traverseObject(objectInfo.addObject(), child, command);
             }
+            // support for custom QObject inherited
+            foreach(QObject* child, quickItem->children()) {
+                QQuickItem* isQuickItem = qobject_cast<QQuickItem*>(child);
+                if (child && !isQuickItem) {
+                    traverseObject(objectInfo.addObject(), child, command);
+                }
+            }
         }
 
         // support for QML Window.
@@ -194,7 +201,6 @@ void TasUiTraverser::traverseObject(TasObject& objectInfo, QObject* object, TasC
                 }
             }
         }
-
         //check decendants
         //1. is graphicsview
         QGraphicsView* gView = qobject_cast<QGraphicsView*>(object);

--- a/tascore/services/screenshotservice.cpp
+++ b/tascore/services/screenshotservice.cpp
@@ -183,7 +183,8 @@ void ScreenshotService::getScreenshot(TasCommandModel& model, TasResponse& respo
                 screenshot.setText("tas_id", objectId(qtQuickWindow));
             }
         } else if (winId) {
-            screenshot = QPixmap::grabWindow(winId, rect.x(), rect.y(), rect.width(), rect.height()).toImage();
+            QWindow* window = getApplicationWindow();
+            screenshot = window->screen()->grabWindow(winId, rect.x(), rect.y(), rect.width(), rect.height()).toImage();
 
             if (!screenshot.isNull()) {
                 screenshot.setText("tas_id", QString::number(winId));

--- a/utilityapp/utilityapp.cpp
+++ b/utilityapp/utilityapp.cpp
@@ -26,6 +26,8 @@
 #include "tasconstants.h"
 
 #include "utilityapp.h"
+#include <QWindow>
+#include <QScreen>
  
 
 TasUtilityApp::TasUtilityApp()
@@ -36,7 +38,12 @@ TasUtilityApp::~TasUtilityApp()
 
 void TasUtilityApp::sendScreenShot(uint id)
 {
-    QPixmap screenshot = QPixmap::grabWindow(QApplication::desktop()->winId());
+    QWindow* window = QWindow::fromWinId(QApplication::desktop()->winId());
+    if (!window) {
+        return;
+    }
+    QPixmap screenshot = QPixmap::fromImage(window->screen()->grabWindow(QApplication::desktop()->winId(), window->x(), window->y(), window->width(), window->height()).toImage());
+
     QByteArray bytes;
     QBuffer buffer(&bytes);
     buffer.open(QIODevice::WriteOnly);


### PR DESCRIPTION
With this code change the cutedriver_visualizer will show all the QObject based objects too. Which includes any custom C++ classes which inherits from QObject and are used inside the QML application.

Another commit includes a fix for the QPixmap::grabWindow is deprecated warning which appears to logs, used QScreen::grabWindow as suggested by the warning.
