### PR TITLE
Fixed issue #31: Added support for port configuration

### DIFF
--- a/qttasserver/corelib/tasserver.cpp
+++ b/qttasserver/corelib/tasserver.cpp
@@ -73,7 +73,7 @@
 /*!
   Constructs a new TasServer with \a parent.
 */
-TasServer::TasServer(QString hostBinding, QObject *parent)
+TasServer::TasServer(QString hostBinding, int hostPort, QObject *parent)
     : QObject(parent)
 {
     TasLogger::logger()->setLogFile("qttasserver.log");
@@ -121,6 +121,8 @@ TasServer::TasServer(QString hostBinding, QObject *parent)
     else{
         mHostBinding = QHostAddress::Any;
     }
+
+    mHostPort = hostPort;
 
     connect(QCoreApplication::instance(), SIGNAL(aboutToQuit()), this, SLOT(shutdown()));
 }
@@ -189,7 +191,7 @@ void TasServer::killAllStartedProcesses()
 void TasServer::createServers()
 {
     if(!mTcpServer){
-        mTcpServer = new TasTcpServer(QT_SERVER_PORT_OUT, *mServiceManager,this);
+        mTcpServer = new TasTcpServer(mHostPort, *mServiceManager,this);
     }
 #if defined(TAS_USELOCALSOCKET)
     if(!mLocalServer){

--- a/qttasserver/corelib/tasserver.h
+++ b/qttasserver/corelib/tasserver.h
@@ -52,7 +52,7 @@ class TasServer : public QObject
     Q_OBJECT
 
 public:
-    TasServer(QString hostBinding, QObject *parent = 0 );
+    TasServer(QString hostBinding, int hostPort = QT_SERVER_PORT_OUT, QObject *parent = 0 );
     ~TasServer();
 
     bool startServer();
@@ -72,6 +72,7 @@ private:
 
 public:
     QHostAddress mHostBinding;
+    int mHostPort;
 
 private:
     TasTcpServer* mTcpServer;

--- a/tascore/conf/qt_testability.ini
+++ b/tascore/conf/qt_testability.ini
@@ -15,3 +15,9 @@ visibility_blacklist="glass,DesktopPageIndicator,SDeclarativeWindowDecoration"
 
 #if "on", qttasserver will start cucumber wire protocol server
 cucumber_wire_server="off"
+
+#currently supports only 'any' or 'localhost'
+hostBinding="any"
+
+#in which port the qttasserver is running
+hostPort=55535


### PR DESCRIPTION
Environment variables:
QTTASSERVER_HOST_BINDING
QTTASSERVER_HOST_PORT

Configuration file properties:
hostBinding
hostPort

Where the hostBinding was already existing, updated also the default qt_testability.ini file to include these.