### PR TITLE
Fixed issue #34: unable to compile TasLayoutTraverse with Qt 5.9 or later

### DIFF
--- a/tascore/corelib/tasqtdatamodel.cpp
+++ b/tascore/corelib/tasqtdatamodel.cpp
@@ -317,6 +317,16 @@ TasAttribute& TasObject::addAttribute(const QString& name, const QString& value)
 /*!
     Add new attribute to the object with the given name and value.
 */
+TasAttribute& TasObject::addAttribute(const QString& name, uint value) {
+    TasAttribute* attribute = new TasAttribute(name);
+    attribute->addValuePlainString(QString::number(value));
+    attributes.append(attribute);
+    return *attribute;
+}
+
+/*!
+    Add new attribute to the object with the given name and value.
+*/
 TasAttribute& TasObject::addAttribute(const QString& name, int value)
 {
 /*

--- a/tascore/corelib/tasqtdatamodel.h
+++ b/tascore/corelib/tasqtdatamodel.h
@@ -102,6 +102,7 @@ public:
     TasAttribute& addAttribute();
     TasAttribute& addAttribute(const QString& name);
     TasAttribute& addAttribute(const QString& name, const QString& value);
+    TasAttribute& addAttribute(const QString& name, uint value);
     TasAttribute& addAttribute(const QString& name, int value);
     TasAttribute& addAttribute(const QString& name, qreal value);
     TasAttribute& addAttribute(const QString& name, const QSize& value);


### PR DESCRIPTION
This will add Qt version specific changes to the TasLayoutTraverse class, which will enable compiling of CuteDriver with Qt 5.9 or later.