### PR TITLE
Fixed issue #36: If Qt is 5.6 or higher, webkit is disabled.

### DIFF
--- a/tasbase.pri
+++ b/tasbase.pri
@@ -22,6 +22,14 @@ TAS_VERSION=2.0.0
 
 #CONFIG += silent
 
+######
+# the Qt Webkit is no longer available since Qt 5.6
+greaterThan(QT_MAJOR_VERSION, 4) {
+  greaterThan(QT_MINOR_VERSION, 5) {
+    CONFIG += no_webkit
+  }
+}
+
 unix:!macx {
   isEmpty(PREFIX) {
     PREFIX = /usr

--- a/traversers/traversers.pro
+++ b/traversers/traversers.pro
@@ -27,8 +27,17 @@ SUBDIRS += layouttraverser
 
 SUBDIRS += scenegraphtraverser
 
-!CONFIG(no_webkit) {
-SUBDIRS += webkittraverser
+######
+# the Qt Webkit is no longer available since Qt 5.6
+greaterThan(QT_MAJOR_VERSION, 4) {
+  greaterThan(QT_MINOR_VERSION, 5) {
+    CONFIG += no_webkit
+  }
 }
+
+!CONFIG(no_webkit) {
+    SUBDIRS += webkittraverser
+}
+
 
 CONFIG  += ordered


### PR DESCRIPTION
The Qt Webkit has been removed since Qt 5.6. Lets disable that now by default for Qt 5.6 or later.

This will remove the need to use CONFIG+=no_webkit for qmake when compiling for Qt 5.6 or later.