### PR TITLE
Added qttas-server.service file to fix #29

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -5,7 +5,7 @@ export DH_VERBOSE=1
 export CFLAGS := $(shell dpkg-buildflags --get CFLAGS) $(shell dpkg-buildflags --get CPPFLAGS) -Wno-deprecated-declarations -Wno-unused-variable
 export CXXFLAGS := $(shell dpkg-buildflags --get CXXFLAGS) $(shell dpkg-buildflags --get CPPFLAGS) -Wno-deprecated-declarations -Wno-unused-variable
 export LDFLAGS := $(shell dpkg-buildflags --get LDFLAGS) -Wl,--as-needed
-export QMAKE_OPTIONS := -r
+export QMAKE_OPTIONS := -r CONFIG+=debian
 export QT_SELECT := qt5
 
 %:

--- a/qttasserver/contrib/qttas-server.service
+++ b/qttasserver/contrib/qttas-server.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=QTTAS Service
+
+[Service]
+ExecStart=/usr/bin/qttasserver
+
+[Install]
+WantedBy=multi-user.target

--- a/qttasserver/qttasserver.pro
+++ b/qttasserver/qttasserver.pro
@@ -68,4 +68,10 @@ wayland {
 DEFINES += TAS_WAYLAND
 }
 
+debian {
+  systemd_service.files=contrib/qttas-server.service
+  systemd_service.path=/lib/systemd/system
+  INSTALLS += systemd_service
+}
+
 INSTALLS += target


### PR DESCRIPTION
debian packaging is missing qttas-server.service, added install rule and a
stub file to fix debian package building.